### PR TITLE
Resolved #1 and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,26 @@ There are times, when though generally in need for queued parallelization, one f
 ```java
 sio.interrupt("Some Token");
 ```
-❗️ Note that this feature is ought to be ❌ removed, when separate queueing for I & O will be ➕ added.
+❗️ Note that this feature is ought to be ❌ removed, as separate queueing for I & O has been ➕ added.
+
+### Separate Queueing
+To allow for more fine grained control of one's I/O-sources, there has been ➕ added a 🎗 support for separate I/O-queueing.
+```java
+try (var i = sio.ientry()) {
+  ...
+  var info = i.readLine();
+  ...
+}
+```
+```java
+try (var o = sio.oentry()) {
+  ...
+  o.write(SOME_BYTE);
+  ...
+}
+```
+As seen here, there also has been added the implementation of the [`Closeable`](https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/io/Closeable.html) interface, which allows for a 😅 save usage - even with 💩 faulty code - and seeks to be a 👍 preferred alternative to the `release` method. Of course this is also true for combined I/O.
+
 ## Notice
 While all entry methods are 🚫 ✋ non-blocking, read and write methods are. Consider this when using IO, because you are 😞 not save from creating 🔥 dead-locks.
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.severinnitsche</groupId>
   <artifactId>IO</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
 
   <developers>
     <developer>

--- a/src/com.github.severinnitsche.io/com/github/severinnitsche/io/SyncedIOStream.java
+++ b/src/com.github.severinnitsche.io/com/github/severinnitsche/io/SyncedIOStream.java
@@ -41,7 +41,7 @@ public class SyncedIOStream {
   * Non blocking method to queue a new {@link com.github.severinnitsche.io.IOStream}
   * @return a new IOStream
   */
-  public IOStream entry() {
+  public synchronized IOStream entry() {
     var io = new IOStream(this);
     iqueue.offer(io);
     oqueue.offer(io);
@@ -142,6 +142,7 @@ public class SyncedIOStream {
   * @param s The string
   * @throws IOException when the underlying stream throws an exception
   */
+  @Deprecated
   public void interrupt(String s) throws IOException {
     synchronized(output) {
       for(byte b : s.getBytes())


### PR DESCRIPTION
This pull request addresses the issue in #1 and updates the Readme. It also officially deprecates the interrupt method because it won't be longer necessary as it described goal may be achieved using the lately added - and now enhanced - separate queueing mechanisms. 